### PR TITLE
Docker: ImportError: cannot import name 'read_serial_port'

### DIFF
--- a/app/dsmr_datalogger_api_client.py
+++ b/app/dsmr_datalogger_api_client.py
@@ -1,82 +1,83 @@
 """
-    NOTE: This script asumes:
+    https://dsmr-reader.readthedocs.io/en/latest/installation/datalogger.html
 
-    - Smart meter supporting DSMR v4+ (see settings around line 40).
-    - The default serial port for the cable at ttyUSB0 (also see settings around line 40).
+    Installation:
+        pip3 install pyserial==3.4 requests==2.22.0
+"""
+import datetime
+import logging
+import time
+
+import serial
+import requests
+
 
 """
-from time import sleep
-
-from serial.serialutil import SerialException
-import requests
-import serial
-import os
-
-
+    These settings are only used when using this script as a dedicated remote datalogger.
+"""
 DSMR_SERIALPORT = os.environ.get('DSMR_SERIALPORT', '/dev/ttyUSB0')
 DSMR_HOST = os.environ.get('DSMR_HOST', '127.0.0.1')
 DSMR_APIKEY = os.environ.get('DSMR_APIKEY', 'APIKEY-BLABLABLA-ABCDEFGHI')
 DSMR_DSMVERSION = os.environ.get('DSMR_DSMVER', '4')
 
+# Default v4+
+SERIAL_BAUDRATE = 115200
+SERIAL_BYTESIZE = serial.EIGHTBITS
+SERIAL_PARITY = serial.PARITY_EVEN
 
+if DSMR_DSMVERSION == '2':
+    SERIAL_BAUDRATE = 9600
+    SERIAL_BYTESIZE = serial.SEVENBITS
+    SERIAL_PARITY = serial.STOPBITS_ONE
+
+SERIAL_SETTINGS = dict(
+    port=DSMR_SERIALPORT,
+    baudrate=SERIAL_BAUDRATE,
+    bytesize=SERIAL_BYTESIZE,
+    parity=SERIAL_PARITY,
+    stopbits=serial.STOPBITS_ONE,
+    xonxoff=1,
+    rtscts=0,
+    timeout=20,
+)
 API_SERVERS = (
-    # You can add multiple hosts here... just copy the line below and paste it directly under it.
+    # You can add multiple hosts here... just uncomment the line below.
     ('http://{}/api/v1/datalogger/dsmrreading'.format(DSMR_HOST), '{}'.format(DSMR_APIKEY)),
+    # ('http://HOST-OR-IP-2/api/v1/datalogger/dsmrreading', 'APIKEY-2'),
 )
 
 
-def main():
-    print('Starting...')
-
-    for telegram in read_telegram():
-        print('Telegram read')
-        print(telegram)
-
-        for current_server in API_SERVERS:
-            api_url, api_key = current_server
-
-            print('Sending telegram to:', api_url)
-
-            try:
-                send_telegram(telegram, api_url, api_key)
-            except Exception as error:
-                print('[!] {}'.format(error))
-
-        sleep(1)
-
-
-def read_telegram():
-    """ Reads the serial port until we can create a reading point. """
-    serial_handle = serial.Serial()
-    serial_handle.port = DSMR_SERIALPORT
-    if DSMR_DSMVERSION == '2':
-        serial_handle.baudrate = 9600 
-        serial_handle.bytesize = serial.SEVENBITS
-        serial_handle.parity = serial.PARITY_EVEN
-        serial_handle.stopbits = serial.STOPBITS_ONE
-    else:
-        serial_handle.baudrate = 115200
-        serial_handle.bytesize = serial.EIGHTBITS
-        serial_handle.parity = serial.PARITY_NONE
-        serial_handle.stopbits = serial.STOPBITS_ONE
-    serial_handle.xonxoff = 1
-    serial_handle.rtscts = 0
-    serial_handle.timeout = 20
-
-    # This might fail, but nothing we can do so just let it crash.
-    serial_handle.open()
+def read_serial_port(port, baudrate, bytesize, parity, stopbits, xonxoff, rtscts, timeout):
+    """
+    Opens the serial port, keeps reading until we have a full telegram and yields the result to preserve the connection.
+    """
+    logging.info('[%s] Opening serial port: %s', datetime.datetime.now(), port)
+    serial_handle = serial.Serial(
+        port=port,
+        baudrate=baudrate,
+        bytesize=bytesize,
+        parity=parity,
+        stopbits=stopbits,
+        xonxoff=xonxoff,
+        rtscts=rtscts,
+        timeout=timeout
+    )
 
     telegram_start_seen = False
     buffer = ''
 
-    # Just keep fetching data until we got what we were looking for.
     while True:
         try:
+            # Wwe use an infinite datalogger loop and signals to break out of it. Serial
+            # operations however do not work well with interrupts, so we'll have to check for E-INTR error.
             data = serial_handle.readline()
-        except SerialException as error:
+        except serial.SerialException as error:
+            if str(error) == 'read failed: [Errno 4] Interrupted system call':
+                # If we were signaled to stop, we still have to finish our loop.
+                continue
+
             # Something else and unexpected failed.
-            print('Serial connection failed:', error)
-            return  # Break out of yield.
+            raise
 
         try:
             # Make sure weird characters are converted properly.
@@ -84,39 +85,54 @@ def read_telegram():
         except TypeError:
             pass
 
-        # This guarantees we will only parse complete telegrams. (issue #74)
         if data.startswith('/'):
             telegram_start_seen = True
-
-            # But make sure to RESET any data collected as well! (issue #212)
             buffer = ''
 
-        # Delay any logging until we've seen the start of a telegram.
         if telegram_start_seen:
             buffer += data
 
-        # Telegrams ends with '!' AND we saw the start. We should have a complete telegram now.
         if data.startswith('!') and telegram_start_seen:
+            # Keep connection open.
             yield buffer
 
-            # Reset the flow again.
-            telegram_start_seen = False
-            buffer = ''
 
-
-def send_telegram(telegram, api_url, api_key):
-    # Register telegram by simply sending it to the application with a POST request.
+def send_telegram_to_remote_dsmrreader(telegram, api_url, api_key):
+    """ Registers a telegram by simply sending it to the application with a POST request. """
     response = requests.post(
         api_url,
-        headers={'X-AUTHKEY': api_key},
+        headers={'Authorization': 'Token {}'.format(api_key)},
         data={'telegram': telegram},
+        timeout=60,  # Prevents this script from hanging indefinitely when the server or network is unavailable.
     )
 
-    # Old versions of DSMR-reader return 200, new ones 201.
-    if response.status_code not in (200, 201):
-        # Or you will find the error (hint) in the reponse body on failure.
-        print('API error: {}'.format(response.text))
+    if response.status_code != 201:
+        logging.error('[%s] API error: HTTP %d - %s', datetime.datetime.now(), response.status_code, response.text)
 
 
-if __name__ == '__main__':
+def main():
+    """ Entrypoint for command line execution. """
+    logging.getLogger().setLevel(logging.INFO)
+    logging.info('[%s] Starting...', datetime.datetime.now())
+
+    for telegram in read_serial_port(**SERIAL_SETTINGS):
+        logging.info('[%s] Telegram read', datetime.datetime.now())
+
+        for current_server in API_SERVERS:
+            current_api_url, current_api_key = current_server
+            logging.info('[%s] Sending telegram to: %s', datetime.datetime.now(), current_api_url)
+
+            try:
+                send_telegram_to_remote_dsmrreader(
+                    telegram=telegram,
+                    api_url=current_api_url,
+                    api_key=current_api_key
+                )
+            except Exception as error:
+                logging.exception(error)
+
+        time.sleep(SLEEP)
+
+
+if __name__ == '__main__':  # pragma: no cover
     main()


### PR DESCRIPTION
- Sinds DSMR-reader v3.3 is er een nieuwe versie van het datalogger-script: https://github.com/dennissiemensma/dsmr-reader/blob/v3.3.0/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py

- Gebruikers krijgen nu fouten door de refactoring: https://github.com/dennissiemensma/dsmr-reader/issues/877

- Ik weet niet exact waardoor het komt, maar mogelijk komt het door de refactoring van het script in dsmr-reader zelf, terwijl er nog een vorige versie in deze ualex-repo zit.

# Waarschuwing
**Neem deze PR niet zomaar over!** Het is puur een voorzet om de nieuwe versie van het script te integeren. Ik kan het zelf niet makkelijk testen.